### PR TITLE
chore: upgrade requests unixsocket

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     GitPython>=3.1.0,<3.2
     filelock>=3.15.1,<4
     platformdirs>=4.2,<5
-    requests_unixsocket>=0.3.0
+    requests_unixsocket2>=0.4.0
     urllib3 >= 1.26.0, < 2.0.0
     eth2spec @ git+https://github.com/ethereum/consensus-specs.git@d08a91cad5a8657e57750b7cfe3ac2178b3d9c0c
 


### PR DESCRIPTION
Replaces `requests_unixsocket` with `requests_unixsocket2`. This is a fork of the existing version that is maintained.

The change fixes this [issue](https://github.com/msabramo/requests-unixsocket/issues/73) when running the following within EEST:
```
uv fill ... --evm-bin=ethereum-spec-evm-resolver
```


Without it we get the same error as mentioned within the issue:

**`requests.exceptions.InvalidURL: Not supported URL scheme http+unix`**

Please see the following [message](https://github.com/msabramo/requests-unixsocket/issues/73#issuecomment-2125848213) within the issue:

> FYI to all: since this project seems to be abandoned, but its longevity is important to my team, we've forked the project as requests-unixsocket2. It should be a drop in replacement for this package.
> 
>     PyPI: https://pypi.org/project/requests-unixsocket2/0.4.0/
>     Repository: https://gitlab.com/thelabnyc/requests-unixsocket2
> 
> We've migrated the fix for this issue there, merged it, and released to PyPI as part of [v0.4.0](https://pypi.org/project/requests-unixsocket2/0.4.0/).

