### PR TITLE
fix: create a shorter, more deterministic socket path

### DIFF
--- a/src/ethereum_spec_evm_resolver/daemon.py
+++ b/src/ethereum_spec_evm_resolver/daemon.py
@@ -3,6 +3,7 @@ import os
 import socketserver
 import subprocess
 import sys
+import tempfile
 import time
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
@@ -17,7 +18,7 @@ from requests_unixsocket import Session
 
 from .forks import get_fork_resolution
 
-runtime_dir = Path(user_runtime_dir("ethereum-spec-evm-resolver"))
+runtime_dir = Path(tempfile.TemporaryDirectory().name)
 
 
 class _EvmToolHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
This resolves the following fails (`OSError: AF_UNIX path too long`) observed in Github Actions on macOS runners observed in ethereum/execution-spec-tests#792. 

This fail was only observed when executing `pytester`-based framework tests (not when filling `./tests!). These pytester-based tests are used to test EEST's pytest plugins. These executes a "pytest sub-session" (from within pytest) from newly created temp directory. They also copy many required files here in this temp directory, including `ethereum-spec-evm-resolver/Merge/src/ethereum_spec_tools/evm_tools/daemon.py` which resulted in a path that is over the max socket length path.

I don't understand why the max socket path length wasn't hit on Linux systems (https://serverfault.com/a/641387), perhaps Ubuntu builds Python with a longer `UNIX_PATH_MAX` on Linux vs macOS?

```
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/Users/runner/work/execution-spec-tests/execution-spec-tests/.tox/framework/bin/ethereum-spec-evm-resolver", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/runner/work/execution-spec-tests/execution-spec-tests/.tox/framework/lib/python3.11/site-packages/ethereum_spec_evm_resolver/main.py", line 43, in main
    sys.exit(Daemon_(args).run())
             ^^^^^^^^^^^^^^^^^^^
  File "/private/var/folders/0g/hj_q_pzx65bbjnslxz9n0src0000gn/T/pytest-of-runner/pytest-1/test_fixture_output_based_on_command_line_args0/Library/Caches/ethereum-spec-evm-resolver/Merge/src/ethereum_spec_tools/evm_tools/daemon.py", line 153, in run
    return self._run()
           ^^^^^^^^^^^
  File "/private/var/folders/0g/hj_q_pzx65bbjnslxz9n0src0000gn/T/pytest-of-runner/pytest-1/test_fixture_output_based_on_command_line_args0/Library/Caches/ethereum-spec-evm-resolver/Merge/src/ethereum_spec_tools/evm_tools/daemon.py", line 138, in _run
    with _UnixSocketHttpServer(
         ^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/folders/0g/hj_q_pzx65bbjnslxz9n0src0000gn/T/pytest-of-runner/pytest-1/test_fixture_output_based_on_command_line_args0/Library/Caches/ethereum-spec-evm-resolver/Merge/src/ethereum_spec_tools/evm_tools/daemon.py", line 81, in __init__
    super().__init__(*args, **kwargs)
  File "/Users/runner/.local/share/uv/python/cpython-3.11.9-macos-aarch64-none/lib/python3.11/socketserver.py", line 456, in __init__
    self.server_bind()
  File "/Users/runner/.local/share/uv/python/cpython-3.11.9-macos-aarch64-none/lib/python3.11/socketserver.py", line 472, in server_bind
    self.socket.bind(self.server_address)
OSError: AF_UNIX path too long
```