### PR TITLE
chore(deps): bump `py-ecc` to match version in `ethereum-execution==1.17.0rc6.dev1`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     platformdirs>=4.2,<5
     requests_unixsocket2>=0.4.0
     urllib3 >= 1.26.0, < 2.0.0
-    py_ecc @ git+https://github.com/petertdavies/py_ecc.git@127184f4c57b1812da959586d0fe8f43bb1a2389
+    py-ecc >= 8.0.0b2, < 9
     pydantic >=2.9.2, <3
 
 [options.entry_points]


### PR DESCRIPTION
This fixes the `py-ecc` package conflict between:
- `ethereum-execution==1.17.0rc6.dev1`: requires `py-ecc>=8.0.0b2,<9`, see https://github.com/ethereum/execution-specs/commit/8d6093a3983dbbf98ebdb84daadef74445050dad
- `ethereum-spec-evm-resolver` currently requires `py_ecc @ git+https://github.com/petertdavies/py_ecc.git@127184f4c57b1812da959586d0fe8f43bb1a2389`

Due to this conflict, we can't use the EELS release package (`ethereum-execution` which gets built from execution-specs `forks/prague`) in execution-spec-tests. 

If the resolver sticks around, we should probably remove the dependency entirely here, but that could cause other potential problems due to missing dependencies. This change should be ok for now, but we should also update execution-specs master to use the same version, if possible, see:
- https://github.com/ethereum/execution-specs/pull/1154