### PR TITLE
chore(cli): silence benign EELS resolver errors

### DIFF
--- a/src/ethereum_spec_evm_resolver/daemon.py
+++ b/src/ethereum_spec_evm_resolver/daemon.py
@@ -17,14 +17,14 @@ from urllib.parse import urlunparse, quote, urlparse
 
 from requests.exceptions import ConnectionError
 from requests_unixsocket import Session
-
+from .error_silencer import apply_benign_error_silencer
 from .forks import (
     get_fork_resolution,
     get_fork_resolution_info,
 )
 
-
 runtime_dir = Path(tempfile.TemporaryDirectory().name)
+apply_benign_error_silencer()
 
 
 class _EvmToolHandler(BaseHTTPRequestHandler):

--- a/src/ethereum_spec_evm_resolver/error_silencer.py
+++ b/src/ethereum_spec_evm_resolver/error_silencer.py
@@ -1,0 +1,43 @@
+"""
+This module provides a function to suppress specific benign errors that can appear
+during normal operation of HTTP servers, particularly when using Python's built-in
+HTTP server implementation with Unix sockets.
+"""
+import socketserver
+import sys
+from http.server import BaseHTTPRequestHandler
+
+def apply_benign_error_silencer():
+    """
+    Silence specific benign errors in HTTP servers that would otherwise clutter logs.
+    
+    1. "I/O operation on closed file" errors:
+       These occur when clients disconnect before the server finishes writing the response.
+       This is normal HTTP connection behavior and not indicative of actual problems.
+
+    2. "Unsupported method ('GET')" errors:
+       These occur when a server receives GET requests (often heartbeat checks) but
+       doesn't have a `do_GET` method implemented. Since these requests are usually just
+       connection checks and don't affect server functionality, we can safely silence them.
+    """
+
+    # 1) Silence "I/O operation on closed file" errors
+    original_handle_error = socketserver.BaseServer.handle_error
+    def custom_handle_error(self, request, client_address):
+        _, exc_value, _ = sys.exc_info()
+        if exc_value is not None:
+            error_message = str(exc_value)
+            if ("I/O operation on closed file" in error_message):
+                return
+        original_handle_error(self, request, client_address)
+    socketserver.BaseServer.handle_error = custom_handle_error
+
+    # 2) Silence "Unsupported method ('GET')" errors 
+    original_log_error = getattr(BaseHTTPRequestHandler, 'log_error', None)
+    if original_log_error is not None:
+        def custom_log_error(self, format, *args):
+            message = format % args if args else format
+            if "code 501, message Unsupported method ('GET')" in message:
+                return
+            original_log_error(self, format, *args)
+        BaseHTTPRequestHandler.log_error = custom_log_error


### PR DESCRIPTION
## Description
When running `fill` in EEST with `-s` (disable output capture), we get noise in the console due to benign errors that don't represent actual problems. For example, when running:

```bash
uv run fill -k "valid_deposit_withdrawal_consolidation_request_from_same_tx" tests/prague/ -m blockchain_test --fork=Prague -vv -s
```

The output is cluttered with two types of benign errors:
1. GET Request Errors: Messages like `code 501, message Unsupported method ('GET')` appear when heartbeat checks are sent to servers that don't implement `do_GET` handlers.
2. I/O Closed File Errors: Traceback messages containing `ValueError: I/O operation on closed file` occur when clients disconnect before the server finishes writing responses - a common scenario in HTTP comms.

## Solution
This PR introduces an error silencer that suppresses these specific messages without affecting other important error reporting. Note I want to make sure we don't silence all the errors as it can be useful to debug for real errors that pop up, hence why [this](https://github.com/ethereum/execution-spec-tests/compare/main...spencer-tb:execution-spec-tests:temp-eels-resolver) is not feasible.

I don't want to spend too much time on this, with the merge in mind. It will make debugging `fill` within EEST easier to read!